### PR TITLE
Fix operator registration and input handling for deterministic demos

### DIFF
--- a/examples/deterministic_demo.py
+++ b/examples/deterministic_demo.py
@@ -293,40 +293,37 @@ async def demo_non_integration():
     print("\n🌐 INTEGRATION WITH NoN NETWORKS")
     print("=" * 50)
 
-    # Create a network that uses deterministic operators
+    # Create a network that uses deterministic operators.
+    # Pipeline: pack raw strings -> select top candidates -> majority vote.
     try:
-        # Note: These operators are registered with the NoN registry
         network = NoN.from_operators(
             [
-                "pack_candidates",  # Structure the data
-                "majority",  # Find consensus
-                "extract_winners",  # Select top results
+                "pack_candidates",  # Structure the raw strings into candidates
+                "extract_winners",  # Select top-scoring candidates
+                "majority",  # Find consensus among the selected candidates
             ]
         )
 
         print("Created NoN network with deterministic operators:")
         print(f"Network layers: {len(network.layers)}")
 
-        # Test data for the network
-        test_input = {
-            "input_data": [
-                "Machine learning enables intelligent automation",
-                "AI systems can automate complex decision making",
-                "Automated intelligence through machine learning",
-                "Machine learning enables intelligent automation",  # Duplicate
-            ]
-        }
+        # Pass the list of strings directly so pack_candidates receives them correctly.
+        test_input = [
+            "Machine learning enables intelligent automation",
+            "AI systems can automate complex decision making",
+            "Automated intelligence through machine learning",
+            "Machine learning enables intelligent automation",  # Duplicate
+        ]
 
-        print(f"\nInput: {len(test_input['input_data'])} responses")
+        print(f"\nInput: {len(test_input)} responses")
 
         # Execute the network
         result = await network.forward(test_input)
-        print(f"\nNetwork output: {type(result)}")
+        print(f"\nNetwork output type: {type(result.final_output).__name__}")
         print(f"Final result: {result}")
 
     except Exception as e:
-        print(f"Network integration demo skipped: {e}")
-        print("(This is expected if running without full NoN environment)")
+        print(f"Network integration demo failed: {e}")
 
 
 async def main():

--- a/nons/core/layer.py
+++ b/nons/core/layer.py
@@ -220,9 +220,16 @@ class Layer:
                 ) from e
 
     def _prepare_inputs(self, inputs: Union[List[Any], Any]) -> List[Any]:
-        """Prepare inputs for each node."""
-        if isinstance(inputs, list) and len(inputs) == len(self.nodes):
-            # Distribute inputs one-to-one with nodes
+        """Prepare inputs for each node.
+
+        When a multi-node layer receives a list whose length matches the node
+        count, each element is distributed 1-to-1.  For single-node layers the
+        input is always broadcast as-is so that operator return values that are
+        lists (e.g. List[Candidate] from extract_winners) are forwarded whole
+        rather than unwrapped.
+        """
+        if isinstance(inputs, list) and len(inputs) == len(self.nodes) and len(self.nodes) > 1:
+            # Distribute inputs one-to-one with nodes (multi-node layers only)
             return inputs
         else:
             # Broadcast single input to all nodes

--- a/nons/operators/deterministic.py
+++ b/nons/operators/deterministic.py
@@ -433,6 +433,7 @@ class SelectById(DeterministicOp):
 
 
 @operator(
+    name="pack_candidates",
     input_schema=InputSchema(
         required_params=["input_data"],
         optional_params=[],
@@ -456,6 +457,7 @@ async def pack_candidates_op(input_data: Any) -> PackedCandidates:
 
 
 @operator(
+    name="extract_winners",
     input_schema=InputSchema(
         required_params=["input_data"],
         optional_params=["strategy", "k", "threshold", "percentile"],
@@ -492,6 +494,7 @@ async def extract_winners_op(
 
 
 @operator(
+    name="majority",
     input_schema=InputSchema(
         required_params=["input_data"],
         optional_params=["strategy", "min_consensus"],
@@ -517,6 +520,7 @@ async def majority_op(
 
 
 @operator(
+    name="select_by_id",
     input_schema=InputSchema(
         required_params=["input_data", "target_ids"],
         optional_params=[],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,3 +92,10 @@ disallow_untyped_defs = true
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.4.2",
+    "pytest-asyncio>=1.2.0",
+    "pytest-mock>=3.15.1",
+]


### PR DESCRIPTION
> **Warning:** Arcanist's verification check flagged a potential mismatch between the requested task and the actual changes. Review carefully.
>
> 

## Summary
- Added explicit `name` parameters to deterministic operator decorators (`pack_candidates`, `extract_winners`, `majority`, `select_by_id`) to ensure correct registry registration
- Fixed `Layer._prepare_inputs()` to only distribute list inputs 1-to-1 on multi-node layers, preventing unwrapping of operator return values (e.g., `List[Candidate]`) in single-node layers
- Updated `deterministic_demo.py` to pass raw string lists directly instead of nested dicts, with improved operator ordering and clearer inline documentation
- Added dev dependency group to `pyproject.toml` with pytest, pytest-asyncio, and pytest-mock

## Test plan
- [ ] Run `examples/deterministic_demo.py` and verify all sections pass, including the NoN 3-layer network integration
- [ ] Verify the NoN network completes successfully with the pipeline: `pack_candidates → extract_winners → majority`
- [ ] Run `examples/basic_non_demo.py` to ensure input handling changes don't break LLM-based operators
- [ ] Confirm dev dependencies install and pytest suite runs without errors

🤖 Generated with [Arcanist](https://tryarcanist.com)

## Verification
- Status: failed
- Summary: 
- Mode: llm