### PR TITLE
Fix three core operator bugs: null params, dict metadata, candidate muta

### DIFF
--- a/nons/core/agents/agent.py
+++ b/nons/core/agents/agent.py
@@ -68,7 +68,7 @@ class Agent:
         """
         tool_result = await self.registry.execute(
             decision.selected_path,
-            decision.params if hasattr(decision, "params") else {},
+            decision.params if decision.params is not None else {},
             state=state,
             **context,
         )

--- a/nons/operators/deterministic.py
+++ b/nons/operators/deterministic.py
@@ -10,7 +10,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import json
 import hashlib
 from collections import Counter
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace as dataclass_replace
 from abc import ABC, abstractmethod
 
 from nons.core.types import InputSchema, OutputSchema, OperatorMetadata
@@ -262,13 +262,14 @@ class ExtractWinners(DeterministicOp):
                 "Input must be PackedCandidates or dict with 'candidates' key"
             )
 
-        # Ensure all candidates have scores
+        # Ensure all candidates have scores, creating new instances to avoid
+        # mutating the originals (which would corrupt cache keys).
         scored_candidates = []
         for candidate in candidates:
             if candidate.score is None:
                 # Default scoring based on content hash (deterministic)
                 score = int(_hash(candidate.content)[:8], 16) / 0xFFFFFFFF
-                candidate.score = score
+                candidate = dataclass_replace(candidate, score=score)
             scored_candidates.append(candidate)
 
         # Sort by score (descending)

--- a/nons/operators/registry.py
+++ b/nons/operators/registry.py
@@ -71,6 +71,8 @@ class OperatorRegistry:
                 examples=[],
                 tags=[],
             )
+        elif isinstance(metadata, dict):
+            metadata = OperatorMetadata(**metadata)
 
         registered_op = RegisteredOperator(
             name=operator_name,

--- a/tests/test_bugfixes.py
+++ b/tests/test_bugfixes.py
@@ -1,0 +1,270 @@
+"""
+Regression tests for three core/operator bug fixes.
+
+Issue #7  - Agent tool execution passes null params (nons/core/agents/agent.py)
+Issue #14 - Operator metadata crashes when registered with dict metadata
+             (nons/operators/registry.py)
+Issue #8  - ExtractWinners mutates input candidates, causing unbounded cache
+             growth (nons/operators/deterministic.py)
+"""
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from nons.core.types import RouteDecision, OperatorMetadata
+from nons.core.agents.agent import Agent
+from nons.core.agents.registry import ToolRegistry
+from nons.operators.registry import OperatorRegistry
+from nons.operators.deterministic import (
+    Candidate,
+    PackedCandidates,
+    ExtractWinners,
+)
+
+
+# ---------------------------------------------------------------------------
+# Issue #7 – Agent._execute_tool passes None params instead of {}
+# ---------------------------------------------------------------------------
+
+
+class TestAgentNullParams:
+    """Regression tests for Issue #7."""
+
+    def _make_agent(self, registry: ToolRegistry) -> Agent:
+        """Return an Agent wired with a stub NoN network."""
+        mock_network = MagicMock()
+        return Agent(network=mock_network, registry=registry)
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_uses_empty_dict_when_params_is_none(self):
+        """
+        When RouteDecision.params is None, _execute_tool must pass {} to
+        ToolRegistry.execute, not None.
+
+        Before the fix, ``hasattr(decision, 'params')`` was always True for
+        Pydantic models so None was forwarded verbatim.
+        """
+        registry = ToolRegistry()
+        captured: list = []
+
+        async def my_tool(params, **ctx):
+            captured.append(params)
+            return {"done": True}
+
+        registry._register("my_tool", "A test tool", my_tool)
+
+        agent = self._make_agent(registry)
+
+        decision = RouteDecision(
+            selected_path="my_tool",
+            routing_confidence=0.9,
+            reasoning="test",
+            params=None,  # Explicitly None – the problematic case
+        )
+
+        result = await agent._execute_tool(decision, state={})
+
+        # The tool must have been called with an empty dict, not None
+        assert len(captured) == 1
+        assert captured[0] == {}, (
+            "Expected {} to be passed when params is None, "
+            f"got {captured[0]!r} instead"
+        )
+        assert result["success"] is True
+
+    @pytest.mark.asyncio
+    async def test_execute_tool_forwards_params_when_provided(self):
+        """
+        When RouteDecision.params is a real dict, it is forwarded as-is.
+        This ensures the fix does not break the happy path.
+        """
+        registry = ToolRegistry()
+        captured: list = []
+
+        async def my_tool(params, **ctx):
+            captured.append(params)
+            return {"done": True}
+
+        registry._register("my_tool", "A test tool", my_tool)
+
+        agent = self._make_agent(registry)
+
+        decision = RouteDecision(
+            selected_path="my_tool",
+            routing_confidence=0.9,
+            reasoning="test",
+            params={"key": "value"},
+        )
+
+        await agent._execute_tool(decision, state={})
+
+        assert captured[0] == {"key": "value"}
+
+
+# ---------------------------------------------------------------------------
+# Issue #14 – OperatorRegistry.register() crashes on dict metadata
+# ---------------------------------------------------------------------------
+
+
+class TestOperatorRegistryDictMetadata:
+    """Regression tests for Issue #14."""
+
+    def test_register_with_dict_metadata_does_not_raise(self):
+        """
+        Passing a plain dict as ``metadata`` must succeed and produce a
+        RegisteredOperator whose .metadata is an OperatorMetadata instance.
+
+        Before the fix, attribute access like .metadata.description would
+        crash with AttributeError because the dict was stored verbatim.
+        """
+        registry = OperatorRegistry()
+
+        async def my_op(text: str) -> str:
+            """My operator docstring."""
+            return text
+
+        metadata_dict = {
+            "name": "my_op",
+            "description": "A dict-metadata operator",
+            "examples": ["example()"],
+            "tags": ["test"],
+        }
+
+        registered = registry.register(func=my_op, name="my_op", metadata=metadata_dict)
+
+        # Attribute access must not raise
+        assert registered.metadata.description == "A dict-metadata operator"
+        assert isinstance(registered.metadata, OperatorMetadata)
+        assert registered.metadata.tags == ["test"]
+
+    def test_register_with_dict_metadata_name_is_used(self):
+        """The 'name' key inside the dict is propagated to OperatorMetadata."""
+        registry = OperatorRegistry()
+
+        async def another_op(x: int) -> int:
+            return x
+
+        registered = registry.register(
+            func=another_op,
+            name="another_op",
+            metadata={"name": "another_op", "description": "desc", "examples": [], "tags": []},
+        )
+
+        assert registered.metadata.name == "another_op"
+
+    def test_register_with_operatormetadata_instance_still_works(self):
+        """
+        Passing an OperatorMetadata instance (the original interface) must
+        continue to work after the dict-normalisation change.
+        """
+        registry = OperatorRegistry()
+
+        async def typed_op(x: str) -> str:
+            return x
+
+        meta = OperatorMetadata(
+            name="typed_op",
+            description="Uses typed metadata",
+            examples=[],
+            tags=["typed"],
+        )
+
+        registered = registry.register(func=typed_op, name="typed_op", metadata=meta)
+
+        assert registered.metadata.description == "Uses typed metadata"
+        assert isinstance(registered.metadata, OperatorMetadata)
+
+    def test_register_with_none_metadata_auto_generates(self):
+        """
+        Passing no metadata (None) still auto-generates an OperatorMetadata
+        from the function name and docstring – existing behaviour preserved.
+        """
+        registry = OperatorRegistry()
+
+        async def auto_op(x: str) -> str:
+            """Auto-generated docstring."""
+            return x
+
+        registered = registry.register(func=auto_op, name="auto_op")
+
+        assert isinstance(registered.metadata, OperatorMetadata)
+        assert "Auto-generated docstring" in registered.metadata.description
+
+
+# ---------------------------------------------------------------------------
+# Issue #8 – ExtractWinners mutates input Candidate objects
+# ---------------------------------------------------------------------------
+
+
+class TestExtractWinnersNoMutation:
+    """Regression tests for Issue #8."""
+
+    def test_transform_does_not_mutate_original_candidates(self):
+        """
+        Candidates that enter ExtractWinners.transform() with score=None must
+        still have score=None after the call; the assigned score must only
+        appear on the returned copies.
+
+        Before the fix, ``candidate.score = score`` modified the dataclass
+        in-place, changing its hash and causing unbounded cache growth.
+        """
+        candidates_without_scores = [
+            Candidate(id="a", content="alpha"),
+            Candidate(id="b", content="beta"),
+            Candidate(id="c", content="gamma"),
+        ]
+        packed = PackedCandidates(candidates=candidates_without_scores)
+
+        op = ExtractWinners(strategy="top_k", k=2, enable_cache=False)
+        winners = op(packed)
+
+        # Returned winners must have scores assigned
+        assert all(w.score is not None for w in winners)
+
+        # Originals must be untouched
+        for original in candidates_without_scores:
+            assert original.score is None, (
+                f"Candidate '{original.id}' was mutated: "
+                f"score changed to {original.score!r}"
+            )
+
+    def test_cache_key_stable_across_repeated_calls(self):
+        """
+        Calling ExtractWinners twice on the same PackedCandidates must hit the
+        cache on the second call (cache size stays at 1, not growing).
+
+        Mutation of the input would change its hash between calls, producing a
+        new cache entry each time.
+        """
+        candidates = [
+            Candidate(id="x", content="xray"),
+            Candidate(id="y", content="yankee"),
+        ]
+        packed = PackedCandidates(candidates=candidates)
+
+        op = ExtractWinners(strategy="top_k", k=1, enable_cache=True)
+
+        op(packed)
+        assert op.cache_stats()["cache_size"] == 1
+
+        op(packed)
+        # Second call must hit cache – size stays at 1
+        assert op.cache_stats()["cache_size"] == 1, (
+            "Cache grew on the second call with identical input, "
+            "indicating the input was mutated between calls"
+        )
+
+    def test_returned_winner_scores_are_deterministic(self):
+        """
+        The score assigned to a scoreless candidate must be the same on every
+        call (derived from a content hash), even without caching.
+        """
+        packed = PackedCandidates(
+            candidates=[Candidate(id="z", content="zulu")]
+        )
+
+        op = ExtractWinners(strategy="top_k", k=1, enable_cache=False)
+        result1 = op(packed)
+        result2 = op(packed)
+
+        assert result1[0].score == result2[0].score


### PR DESCRIPTION
## Summary

- **Issue #7**: Agent tool execution now correctly passes empty dict `{}` instead of `None` when `RouteDecision.params` is null. Changed from `hasattr()` check (always true for Pydantic models) to explicit `is not None` check.

- **Issue #14**: OperatorRegistry.register() now converts dict metadata to OperatorMetadata instances, preventing AttributeError when accessing metadata properties.

- **Issue #8**: ExtractWinners no longer mutates input candidates in-place when assigning scores. Now uses dataclasses.replace() to create new instances, preserving cache key stability and preventing unbounded cache growth.

## Test plan

- [ ] Run `test_bugfixes.py` — 9 regression tests covering all three fixes
- [ ] Verify agent passes empty dict to tools when params is None
- [ ] Verify agent forwards real params unchanged
- [ ] Verify dict metadata converts to OperatorMetadata without raising AttributeError
- [ ] Verify ExtractWinners doesn't mutate input candidates when applying default scores
- [ ] Run full test suite to confirm no regressions

Resolves #7
Resolves #8
Resolves #14

🤖 Generated with [Arcanist](https://tryarcanist.com)

## Verification
- Status: passed
- Summary: 
- Mode: llm