### PR TITLE
Execute retry logic concurrently and fix fallback metrics

### DIFF
--- a/nons/core/layer.py
+++ b/nons/core/layer.py
@@ -312,38 +312,62 @@ class Layer:
     async def _execute_with_retry(
         self, node_inputs: List[Any], node_contexts: List[ExecutionContext]
     ) -> tuple[List[Any], Dict[str, Any]]:
-        """Execute with retry and backoff policy."""
-        outputs = []
-        node_results = {}
+        """Execute with retry and backoff policy, running all nodes concurrently.
 
-        for node, node_input, context in zip(self.nodes, node_inputs, node_contexts):
-            success = False
-            last_error = None
+        Each node independently retries with exponential backoff on failure, but
+        all nodes start concurrently via asyncio.gather() so that one node's
+        retries do not block other nodes from making progress.
+        """
 
+        async def _node_with_retry(
+            node: Node, node_input: Any, context: ExecutionContext
+        ) -> tuple[str, bool, Any, Optional[Exception]]:
+            """Execute a single node with independent retry and exponential backoff.
+
+            Returns:
+                tuple: (node_id, success, output, last_error)
+            """
+            last_error: Optional[Exception] = None
             for attempt in range(self.layer_config.max_retries + 1):
                 try:
                     output = await node.execute(node_input, execution_context=context)
-                    outputs.append(output)
-                    node_results[node.node_id] = {"success": True, "output": output}
-                    success = True
-                    break
+                    return node.node_id, True, output, None
                 except Exception as e:
                     last_error = e
                     if attempt < self.layer_config.max_retries:
-                        # Wait with exponential backoff
+                        # Wait with exponential backoff before next attempt
                         delay = self.layer_config.retry_delay_seconds * (2**attempt)
                         await asyncio.sleep(delay)
+            return node.node_id, False, None, last_error
 
-            if not success:
-                node_results[node.node_id] = {
-                    "success": False,
-                    "error": str(last_error),
-                }
-                if self.layer_config.error_policy == ErrorPolicy.RETRY_WITH_BACKOFF:
-                    # Still fail if retries exhausted
-                    raise OperatorError(
-                        f"Node {node.node_id} failed after {self.layer_config.max_retries} retries: {last_error}"
-                    )
+        # Launch all nodes concurrently; each node retries independently
+        tasks = [
+            asyncio.create_task(
+                _node_with_retry(node, node_input, context),
+                name=f"retry_node_{i}_{node.node_id}",
+            )
+            for i, (node, node_input, context) in enumerate(
+                zip(self.nodes, node_inputs, node_contexts)
+            )
+        ]
+
+        raw_results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        outputs = []
+        node_results = {}
+
+        for raw in raw_results:
+            if isinstance(raw, BaseException):
+                raise raw
+            node_id, success, output, error = raw
+            if success:
+                outputs.append(output)
+                node_results[node_id] = {"success": True, "output": output}
+            else:
+                node_results[node_id] = {"success": False, "error": str(error)}
+                raise OperatorError(
+                    f"Node {node_id} failed after {self.layer_config.max_retries} retries: {error}"
+                )
 
         return outputs, node_results
 

--- a/nons/core/node.py
+++ b/nons/core/node.py
@@ -228,11 +228,16 @@ class Node:
                 result, metrics = await provider.generate_completion(prompt)
                 return result, metrics
             except Exception as e:
-                # If real API fails, fall back to mock provider
+                # If real API fails, fall back to mock provider.
+                # Explicitly reset provider and cost on the returned metrics so
+                # that callers always see accurate fallback attribution even if
+                # the metrics object was pre-populated with real-provider values.
                 from ..utils.providers import MockProvider
 
                 mock_provider = MockProvider(self.model_config)
                 result, metrics = await mock_provider.generate_completion(prompt)
+                metrics.provider = "mock"
+                metrics.cost_info = CostInfo()
                 return result, metrics
 
         # Schedule the request through the global scheduler

--- a/nons/utils/providers.py
+++ b/nons/utils/providers.py
@@ -356,6 +356,22 @@ class GoogleProvider(BaseLLMProvider):
 class MockProvider(BaseLLMProvider):
     """Mock provider for testing and placeholder operations."""
 
+    def __init__(self, model_config: ModelConfig):
+        """
+        Initialize MockProvider, always reporting provider_name as 'mock'.
+
+        This ensures that metrics produced by MockProvider — including those
+        created during a fallback from a failing real provider — always reflect
+        the actual execution path rather than the original model_config provider.
+
+        Args:
+            model_config: Model configuration (provider field is ignored for naming).
+        """
+        super().__init__(model_config)
+        # Override the provider name inherited from BaseLLMProvider so that
+        # metrics always report 'mock', regardless of the model_config's provider.
+        self.provider_name = "mock"
+
     async def generate_completion(
         self, prompt: str, system_prompt: Optional[str] = None, **kwargs
     ) -> tuple[str, ExecutionMetrics]:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,4 @@
-[tool:pytest]
+[pytest]
 testpaths = tests
 python_files = test_*.py
 python_classes = Test*

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -5,7 +5,7 @@ Tests for Layer class parallel execution.
 import pytest
 import asyncio
 from unittest.mock import patch, AsyncMock, MagicMock
-from nons.core.layer import Layer, create_parallel_layer
+from nons.core.layer import Layer, LayerResult, create_parallel_layer
 from nons.core.node import Node
 from nons.core.types import (
     ModelConfig,
@@ -13,7 +13,6 @@ from nons.core.types import (
     ExecutionContext,
     LayerConfig,
     ErrorPolicy,
-    LayerResult,
     OperatorError,
 )
 from tests.conftest import MockLLMProvider, assert_execution_metrics
@@ -576,6 +575,134 @@ class TestLayerTimeout:
 
             with pytest.raises(asyncio.TimeoutError):
                 await layer.execute_parallel("Test input")
+
+
+class TestRetryWithBackoffParallel:
+    """Tests that RETRY_WITH_BACKOFF executes all nodes concurrently (issue #9).
+
+    These tests patch node.execute directly — the method that _execute_with_retry
+    actually calls — rather than the provider factory, which is imported into
+    node.py by value and therefore unaffected by module-level patches.
+    """
+
+    def setup_method(self):
+        """Set up test method."""
+        import nons.operators.base
+
+    async def test_retry_with_backoff_runs_nodes_concurrently(self):
+        """All nodes under RETRY_WITH_BACKOFF must start at the same time.
+
+        With N nodes each sleeping for T seconds, parallel execution finishes
+        in approximately T seconds, whereas sequential execution would take N*T.
+        If the implementation were still sequential, this assertion would fail.
+        """
+        import time
+
+        config = ModelConfig(provider=ModelProvider.MOCK, model_name="test")
+        num_nodes = 3
+        sleep_duration = 0.15  # 150 ms per node
+
+        nodes = [Node("generate", config) for _ in range(num_nodes)]
+        layer_config = LayerConfig(
+            error_policy=ErrorPolicy.RETRY_WITH_BACKOFF,
+            max_retries=0,
+            retry_delay_seconds=0.0,
+        )
+        layer = Layer(nodes, layer_config=layer_config)
+
+        async def slow_execute(*args, **kwargs):
+            await asyncio.sleep(sleep_duration)
+            return "ok"
+
+        patches = [
+            patch.object(node, "execute", new=AsyncMock(side_effect=slow_execute))
+            for node in nodes
+        ]
+        for p in patches:
+            p.start()
+        try:
+            start = time.monotonic()
+            result = await layer.execute_parallel("test")
+            elapsed = time.monotonic() - start
+        finally:
+            for p in patches:
+                p.stop()
+
+        assert len(result.outputs) == num_nodes
+        assert result.success_rate == 1.0
+        # Sequential execution would take >= num_nodes * sleep_duration.
+        # Parallel execution should finish well within that bound (allowing
+        # 2x single-node duration for scheduling overhead).
+        sequential_lower_bound = num_nodes * sleep_duration * 0.9
+        assert elapsed < sequential_lower_bound, (
+            f"Elapsed {elapsed:.3f}s >= sequential lower bound {sequential_lower_bound:.3f}s; "
+            "nodes appear to be executing sequentially instead of in parallel"
+        )
+
+    async def test_retry_with_backoff_nodes_retry_independently(self):
+        """Each node retries on its own schedule without blocking other nodes.
+
+        Node A fails on the first attempt and succeeds on retry.
+        Node B always succeeds on the first attempt.
+        Both should complete successfully regardless of node A's retry.
+        """
+        config = ModelConfig(provider=ModelProvider.MOCK, model_name="test")
+
+        node_a = Node("generate", config)
+        node_b = Node("generate", config)
+
+        layer_config = LayerConfig(
+            error_policy=ErrorPolicy.RETRY_WITH_BACKOFF,
+            max_retries=2,
+            retry_delay_seconds=0.001,  # tiny delay to keep the test fast
+        )
+        layer = Layer([node_a, node_b], layer_config=layer_config)
+
+        # Track how many times each node's execute() is called.
+        call_counts = {"a": 0, "b": 0}
+
+        async def node_a_execute(*args, **kwargs):
+            call_counts["a"] += 1
+            if call_counts["a"] == 1:
+                raise OperatorError("node A first attempt failure")
+            return "output-a"
+
+        async def node_b_execute(*args, **kwargs):
+            call_counts["b"] += 1
+            return "output-b"
+
+        with patch.object(node_a, "execute", new=AsyncMock(side_effect=node_a_execute)):
+            with patch.object(node_b, "execute", new=AsyncMock(side_effect=node_b_execute)):
+                result = await layer.execute_parallel("test")
+
+        assert result.success_rate == 1.0
+        assert len(result.outputs) == 2
+        # Node A needed 2 calls (1 failure + 1 retry success)
+        assert call_counts["a"] == 2, (
+            f"Expected node A to be called 2 times (1 fail + 1 retry), got {call_counts['a']}"
+        )
+        # Node B needed only 1 call (no failures)
+        assert call_counts["b"] == 1, (
+            f"Expected node B to be called 1 time, got {call_counts['b']}"
+        )
+
+    async def test_retry_with_backoff_raises_when_all_retries_exhausted(self):
+        """Layer must propagate the failure when a node exhausts all retries."""
+        config = ModelConfig(provider=ModelProvider.MOCK, model_name="test")
+        nodes = [Node("generate", config)]
+        layer_config = LayerConfig(
+            error_policy=ErrorPolicy.RETRY_WITH_BACKOFF,
+            max_retries=1,
+            retry_delay_seconds=0.0,
+        )
+        layer = Layer(nodes, layer_config=layer_config)
+
+        async def always_fails(*args, **kwargs):
+            raise OperatorError("permanent node failure")
+
+        with patch.object(nodes[0], "execute", new=AsyncMock(side_effect=always_fails)):
+            with pytest.raises(Exception, match="permanent node failure"):
+                await layer.execute_parallel("test")
 
 
 @pytest.mark.unit

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -5,7 +5,7 @@ Tests for Network (NoN) class sequential execution.
 import pytest
 import asyncio
 from unittest.mock import patch, AsyncMock, MagicMock
-from nons.core.network import NoN
+from nons.core.network import NoN, NetworkResult
 from nons.core.layer import Layer
 from nons.core.node import Node
 from nons.core.types import (
@@ -15,7 +15,6 @@ from nons.core.types import (
     NetworkConfig,
     LayerConfig,
     ErrorPolicy,
-    NetworkResult,
     OperatorError,
 )
 from tests.conftest import MockLLMProvider

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -561,3 +561,89 @@ class TestNodeIntegration:
 
                 assert result is not None
                 assert node._execution_count == 1
+
+
+class TestMockProviderFallbackMetrics:
+    """Tests that metrics correctly reflect MockProvider fallback (issue #11)."""
+
+    def setup_method(self):
+        """Set up test method."""
+        import nons.operators.base
+
+    def test_mock_provider_always_sets_provider_name_to_mock(self):
+        """MockProvider.__init__ must set provider_name='mock' regardless of model_config.
+
+        Without the fix, provider_name would inherit the model_config's provider
+        value (e.g. 'openai'), causing metrics to misreport the execution path.
+        """
+        from nons.utils.providers import MockProvider
+
+        for provider_enum in [ModelProvider.OPENAI, ModelProvider.ANTHROPIC, ModelProvider.MOCK]:
+            config = ModelConfig(provider=provider_enum, model_name="some-model")
+            mock_provider = MockProvider(config)
+
+            assert mock_provider.provider_name == "mock", (
+                f"Expected provider_name='mock' when model_config.provider={provider_enum.value}, "
+                f"got '{mock_provider.provider_name}'"
+            )
+
+    async def test_mock_provider_generate_completion_reports_mock_provider_and_zero_cost(self):
+        """Metrics from MockProvider.generate_completion must have provider='mock' and cost=0.
+
+        This verifies the fix in providers.py ensures correct metric attribution
+        even when MockProvider is constructed from a real-provider model_config.
+        """
+        from nons.utils.providers import MockProvider
+
+        config = ModelConfig(provider=ModelProvider.OPENAI, model_name="gpt-4")
+        mock_provider = MockProvider(config)
+
+        result_text, metrics = await mock_provider.generate_completion("hello")
+
+        assert metrics.provider == "mock", (
+            f"Expected metrics.provider='mock', got '{metrics.provider}'"
+        )
+        assert metrics.cost_info.total_cost_usd == 0.0, (
+            f"Expected zero cost for mock provider, got {metrics.cost_info.total_cost_usd}"
+        )
+
+    async def test_node_fallback_metrics_report_mock_provider_and_zero_cost(self):
+        """When the real provider raises and node falls back to MockProvider, metrics must
+        show provider='mock' and cost=0, not the original provider name and price.
+
+        This covers the fix in node.py (_execute_request fallback block) and
+        providers.py (MockProvider.__init__) together.
+        """
+        config = ModelConfig(provider=ModelProvider.OPENAI, model_name="gpt-4o")
+        node = Node("generate", model_config=config)
+
+        with patch("nons.core.node.create_provider") as mock_create_provider:
+            # Simulate a real provider that always raises
+            failing_prov = MagicMock()
+            failing_prov.generate_completion = AsyncMock(
+                side_effect=Exception("simulated API failure")
+            )
+            mock_create_provider.return_value = failing_prov
+
+            with patch("nons.core.scheduler.get_scheduler") as mock_get_scheduler:
+                scheduler = MagicMock()
+                # Make scheduler call the operation directly so we exercise
+                # _execute_request and its fallback path.
+                scheduler.schedule_request = AsyncMock(
+                    side_effect=lambda operation, **kwargs: operation()
+                )
+                mock_get_scheduler.return_value = scheduler
+
+                result = await node.execute("some prompt")
+
+        metrics = node.get_last_metrics()
+        assert metrics is not None, "Node should have recorded metrics after execution"
+
+        assert metrics.provider == "mock", (
+            f"After fallback to MockProvider, expected metrics.provider='mock', "
+            f"got '{metrics.provider}'"
+        )
+        assert metrics.cost_info.total_cost_usd == 0.0, (
+            f"After fallback to MockProvider, expected cost=0, "
+            f"got {metrics.cost_info.total_cost_usd}"
+        )

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -5,9 +5,9 @@ Tests for observability system (tracing, logging, metrics).
 import pytest
 import time
 from unittest.mock import patch, MagicMock
-from nons.observability.tracing import TracingManager, Span, SpanKind, SpanStatus
-from nons.observability.logging import LoggingManager, LogLevel
-from nons.observability.metrics import MetricsManager, MetricType
+from nons.observability.tracing import TraceManager as TracingManager, Span, SpanKind, SpanStatus
+from nons.observability.logging import LogManager as LoggingManager, LogLevel
+from nons.observability.metrics import MetricsCollector as MetricsManager, MetricType
 from nons.observability.integration import (
     ObservabilityManager,
     get_observability,


### PR DESCRIPTION
## Summary

- **Concurrent node execution with independent retries**: Refactored `_execute_with_retry` in `layer.py` to launch all nodes simultaneously via `asyncio.gather()` instead of sequentially. Each node retries independently with exponential backoff, so one node's retries no longer block others from progressing.
- **Accurate fallback provider metrics**: Fixed `MockProvider` to always report provider name as "mock" via `__init__` override, and defensively reset metrics in the fallback exception handler. This ensures callers always see correct attribution when a real provider fails and falls back to the mock.
- **Test infrastructure**: Corrected `pytest.ini` header to `[pytest]` so async mode configuration is applied; fixed stale imports in test files; added new tests for concurrent retry behavior and mock fallback metrics.

## Test plan

- [ ] Run all tests in `tests/test_layer.py::TestRetryWithBackoffParallel` to verify concurrent execution timing and per-node retry independence
- [ ] Run all tests in `tests/test_node.py::TestMockProviderFallbackMetrics` to verify fallback metrics report "mock" provider and zero cost
- [ ] Run full test suite to ensure no regressions
- [ ] Verify that with N slow nodes, execution time is ~T (concurrent) not ~N*T (sequential)

🤖 Generated with [Arcanist](https://tryarcanist.com)

## Verification
- Status: passed
- Summary: 
- Mode: llm